### PR TITLE
feat: Replace repository from jcenter to mavenCentral

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ tasks.named<Wrapper>("wrapper") {
 }
 
 repositories {
-  jcenter()
+  mavenCentral()
 }
 dependencies {
   implementation(kotlin("stdlib"))


### PR DESCRIPTION
# 概要
ライブラリの参照先リポジトリをjcenterからmaven centralに置き換えました。